### PR TITLE
Fix an issue: the datetimepicker box won't dismiss

### DIFF
--- a/tempus_dominus/widgets.py
+++ b/tempus_dominus/widgets.py
@@ -18,7 +18,7 @@ class TempusDominusMixin(object):
         )
 
     html_template = """
-        <input type="{type}" name="{name}"{value}{attrs} data-toggle="datetimepicker" data-target="#{picker_id}" id="{picker_id}">
+        <input type="{type}" name="{name}"{value}{attrs} data-toggle="datetimepicker" class="datetimepicker-input form-control" data-target="#{picker_id}" id="{picker_id}">
         <script type="text/javascript">
             $(function () {{
                 $('#{picker_id}').datetimepicker({js_options});


### PR DESCRIPTION
As what happened in my project, the DateTime picker box will not dismiss unless the user clicks the input field for a second time. That creates a bad user experience.
After doing a little trick, the DateTime picker box should dismiss if the input field loses focus.