### PR TITLE
Option to l10n and i18n to all pickers

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ Three widgets are provided:
 * `DateTimePicker`, which defaults to `YYYY-MM-DD HH:mm:ss`
 * `TimePicker`, which defaults to `HH:mm:ss`
 
+If you set TEMPUS_DOMINUS_LOCALIZE in Django settings to True, widgets will be translated to browser language and use localised date and time formats
+
 In your Django form, you can use the widgets like this:
 
 ```python

--- a/setup.py
+++ b/setup.py
@@ -30,5 +30,5 @@ setup(
         'Framework :: Django :: 2.0',
         'Topic :: Internet :: WWW/HTTP',
         'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
-    ],
+    ], install_requires=['django']
 )

--- a/tempus_dominus/widgets.py
+++ b/tempus_dominus/widgets.py
@@ -5,6 +5,8 @@ from django.forms.widgets import DateInput, DateTimeInput, TimeInput
 from django.utils.safestring import mark_safe
 from django.utils.encoding import force_text
 from django.utils.formats import get_format
+from django.utils.translation import get_language
+from django.conf import settings
 
 
 class TempusDominusMixin(object):
@@ -14,8 +16,13 @@ class TempusDominusMixin(object):
                 '//cdnjs.cloudflare.com/ajax/libs/tempusdominus-bootstrap-4/5.0.1/css/tempusdominus-bootstrap-4.min.css',
             ),
         }
+
+        if (getattr(settings, 'TEMPUS_DOMINUS_LOCALIZE', False)):
+            moment = "moment-with-locales"
+        else:
+            moment = "moment"
         js = (
-            '//cdnjs.cloudflare.com/ajax/libs/moment.js/2.22.2/moment.min.js',
+            '//cdnjs.cloudflare.com/ajax/libs/moment.js/2.22.2/{moment}.min.js'.format(moment=moment),
             '//cdnjs.cloudflare.com/ajax/libs/tempusdominus-bootstrap-4/5.0.1/js/tempusdominus-bootstrap-4.min.js',
         )
 
@@ -43,6 +50,8 @@ class TempusDominusMixin(object):
                 key=attr_key,
                 value=attr_value,
             )
+        if (getattr(settings, 'TEMPUS_DOMINUS_LOCALIZE', False)):
+            self.js_options['locale'] = get_language()
 
         options = json_dumps(self.js_options)
         if context['widget']['value'] is not None:
@@ -95,18 +104,33 @@ class TempusDominusMixin(object):
 
 
 class DatePicker(TempusDominusMixin, DateInput):
+    if (getattr(settings, 'TEMPUS_DOMINUS_LOCALIZE', False)):
+        js_format = 'L'
+    else:
+        js_format = 'YYYY-MM-DD'
+
     js_options = {
-        'format': 'YYYY-MM-DD',
+        'format': js_format,
     }
 
 
 class DateTimePicker(TempusDominusMixin, DateTimeInput):
+    if (getattr(settings, 'TEMPUS_DOMINUS_LOCALIZE', False)):
+        js_format = 'L LTS'
+    else:
+        js_format = 'YYYY-MM-DD HH:mm:ss'
+
     js_options = {
-        'format': 'YYYY-MM-DD HH:mm:ss',
+        'format': js_format
     }
 
 
 class TimePicker(TempusDominusMixin, TimeInput):
+    if (getattr(settings, 'TEMPUS_DOMINUS_LOCALIZE', False)):
+        js_format = 'LTS'
+    else:
+        js_format = 'HH:mm:ss'
+
     js_options = {
-        'format': 'HH:mm:ss',
+        'format': js_format
     }

--- a/tempus_dominus/widgets.py
+++ b/tempus_dominus/widgets.py
@@ -17,7 +17,7 @@ class TempusDominusMixin(object):
             ),
         }
 
-        if (getattr(settings, 'TEMPUS_DOMINUS_LOCALIZE', False)):
+        if getattr(settings, 'TEMPUS_DOMINUS_LOCALIZE', False):
             moment = "moment-with-locales"
         else:
             moment = "moment"
@@ -50,7 +50,7 @@ class TempusDominusMixin(object):
                 key=attr_key,
                 value=attr_value,
             )
-        if (getattr(settings, 'TEMPUS_DOMINUS_LOCALIZE', False)):
+        if getattr(settings, 'TEMPUS_DOMINUS_LOCALIZE', False) and 'locale' not in self.js_options:
             self.js_options['locale'] = get_language()
 
         options = json_dumps(self.js_options)
@@ -104,7 +104,7 @@ class TempusDominusMixin(object):
 
 
 class DatePicker(TempusDominusMixin, DateInput):
-    if (getattr(settings, 'TEMPUS_DOMINUS_LOCALIZE', False)):
+    if getattr(settings, 'TEMPUS_DOMINUS_LOCALIZE', False):
         js_format = 'L'
     else:
         js_format = 'YYYY-MM-DD'
@@ -115,7 +115,7 @@ class DatePicker(TempusDominusMixin, DateInput):
 
 
 class DateTimePicker(TempusDominusMixin, DateTimeInput):
-    if (getattr(settings, 'TEMPUS_DOMINUS_LOCALIZE', False)):
+    if getattr(settings, 'TEMPUS_DOMINUS_LOCALIZE', False):
         js_format = 'L LTS'
     else:
         js_format = 'YYYY-MM-DD HH:mm:ss'
@@ -126,7 +126,7 @@ class DateTimePicker(TempusDominusMixin, DateTimeInput):
 
 
 class TimePicker(TempusDominusMixin, TimeInput):
-    if (getattr(settings, 'TEMPUS_DOMINUS_LOCALIZE', False)):
+    if getattr(settings, 'TEMPUS_DOMINUS_LOCALIZE', False):
         js_format = 'LTS'
     else:
         js_format = 'HH:mm:ss'


### PR DESCRIPTION
This pull requests introduces new settings option, TEMPUS_DOMINUS_LOCALIZE
When False (or not at all), the code behaves exactly as before. When true, following things change:
* load moment-with-locales from CDN
* add 'locale' to js_options, set to current locale. Note: this is done at last possible time, so we get run-time locale and not the default one.
* change format options to localized (L, LTS)