### PR TITLE
Adding setting to disable loading assets from CDN

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,10 @@ pip install -e django-tempus-dominus
 
 ## Usage & Settings
 
-A Django setting is provided to use the browser's localized date and time configuration:
+The following settings are available:
 
 * `TEMPUS_DOMINUS_LOCALIZE` (default: `False`): if `True`, widgets will be translated to the selected browser language and use the localized date and time formats.
+* `TEMPUS_DOMINUS_INCLUDE_ASSETS` (default: `True`): if `True`, loads Tempus Dominus and `moment` JS and CSS from Cloudflare's CDN, otherwise loading the JS and CSS are up to you.
 
 Three widgets are provided:
 

--- a/tempus_dominus/widgets.py
+++ b/tempus_dominus/widgets.py
@@ -9,22 +9,27 @@ from django.utils.translation import get_language
 from django.conf import settings
 
 
-class TempusDominusMixin(object):
-    class Media:
-        css = {
-            'all': (
-                '//cdnjs.cloudflare.com/ajax/libs/tempusdominus-bootstrap-4/5.0.1/css/tempusdominus-bootstrap-4.min.css',
-            ),
-        }
+class CDNMedia:
+    css = {
+        'all': (
+            '//cdnjs.cloudflare.com/ajax/libs/tempusdominus-bootstrap-4/5.0.1/css/tempusdominus-bootstrap-4.min.css',
+        ),
+    }
 
-        if getattr(settings, 'TEMPUS_DOMINUS_LOCALIZE', False):
-            moment = "moment-with-locales"
-        else:
-            moment = "moment"
-        js = (
-            '//cdnjs.cloudflare.com/ajax/libs/moment.js/2.22.2/{moment}.min.js'.format(moment=moment),
-            '//cdnjs.cloudflare.com/ajax/libs/tempusdominus-bootstrap-4/5.0.1/js/tempusdominus-bootstrap-4.min.js',
-        )
+    if getattr(settings, 'TEMPUS_DOMINUS_LOCALIZE', False):
+        moment = "moment-with-locales"
+    else:
+        moment = "moment"
+    js = (
+        '//cdnjs.cloudflare.com/ajax/libs/moment.js/2.22.2/{moment}.min.js'.format(moment=moment),
+        '//cdnjs.cloudflare.com/ajax/libs/tempusdominus-bootstrap-4/5.0.1/js/tempusdominus-bootstrap-4.min.js',
+    )
+
+
+class TempusDominusMixin(object):
+
+    if getattr(settings, 'TEMPUS_DOMINUS_INCLUDE_ASSETS', True):
+        Media = CDNMedia
 
     html_template = """
         <input type="{type}" name="{name}"{value}{attrs} data-toggle="datetimepicker" data-target="#{picker_id}" id="{picker_id}">


### PR DESCRIPTION
As requested in https://github.com/FlipperPA/django-tempus-dominus/issues/7, I've added a setting to disable loading the tempus dominus JS and CSS from cloudflare.