### PR TITLE
Rendering widget with Django template instead of string interpolation

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ git clone git+https://github.com/FlipperPA/django-tempus-dominus.git
 pip install -e django-tempus-dominus
 ```
 
+Add `tempus_dominus` to `INSTALLED_APPS` in your Django settings.
+
 ## Usage & Settings
 
 A Django setting is provided to use the browser's localized date and time configuration:

--- a/tempus_dominus/templates/tempus_dominus/widget.html
+++ b/tempus_dominus/templates/tempus_dominus/widget.html
@@ -1,0 +1,6 @@
+<input type="{{ type }}" name="{{ name }}"{{ attrs }} data-toggle="datetimepicker" data-target="#{{ picker_id }}" id="{{ picker_id }}">
+<script type="text/javascript">
+    $(function () {{
+        $('#{{ picker_id }}').datetimepicker({{ js_options }});
+    }});
+</script>

--- a/tempus_dominus/widgets.py
+++ b/tempus_dominus/widgets.py
@@ -7,6 +7,7 @@ from django.utils.encoding import force_text
 from django.utils.formats import get_format
 from django.utils.translation import get_language
 from django.conf import settings
+from django.template.loader import render_to_string
 
 
 class TempusDominusMixin(object):
@@ -25,15 +26,6 @@ class TempusDominusMixin(object):
             '//cdnjs.cloudflare.com/ajax/libs/moment.js/2.22.2/{moment}.min.js'.format(moment=moment),
             '//cdnjs.cloudflare.com/ajax/libs/tempusdominus-bootstrap-4/5.0.1/js/tempusdominus-bootstrap-4.min.js',
         )
-
-    html_template = """
-        <input type="{type}" name="{name}"{value}{attrs} data-toggle="datetimepicker" data-target="#{picker_id}" id="{picker_id}">
-        <script type="text/javascript">
-            $(function () {{
-                $('#{picker_id}').datetimepicker({js_options});
-            }});
-        </script>
-    """
 
     def __init__(self, attrs={'class': 'form-control datetimepicker-input'}, options=None):
         super().__init__(attrs)
@@ -58,14 +50,13 @@ class TempusDominusMixin(object):
             # Append an option to set the datepicker's value using a Javascript moment object
             options = options[:-1] + ', %s}' % self.moment_option(value)
 
-        field_html = self.html_template.format(
-            type=context['widget']['type'],
-            picker_id=context['widget']['attrs']['id'],
-            name=context['widget']['name'],
-            value='',
-            attrs=attr_html,
-            js_options=options,
-        )
+        field_html = render_to_string('tempus_dominus/widget.html', {
+            'type': context['widget']['type'],
+            'picker_id': context['widget']['attrs']['id'],
+            'name': context['widget']['name'],
+            'attrs': mark_safe(attr_html),
+            'js_options': mark_safe(options),
+        })
 
         return mark_safe(force_text(field_html))
 


### PR DESCRIPTION
As requested in https://github.com/FlipperPA/django-tempus-dominus/issues/8, this PR renders the widget with a Django template instead of python string interpolation, which allows for easier overriding of the widget HTML.

Note that this changes requires `tempus_dominus` to be added to `INSTALLED_APPS` for the template to be registered, so this will likely need to be announced when a new version is released. I've added that step to the README.