### PR TITLE
Template coverage and coverage reports on each run

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,3 @@
+[run]
+plugins =
+  django_coverage_plugin

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,3 +1,5 @@
 [pytest]
-addopts = --cov=tempus_dominus
+addopts =
+  --cov=tempus_dominus
+  --cov-report term-missing
 DJANGO_SETTINGS_MODULE = tests.settings

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,4 @@
 pytest-cov
 pytest-django
+django_coverage_plugin==1.6.0
 -e . # installs Django Tempus Dominus from this directory


### PR DESCRIPTION
Need to install `django_coverage_plugin==1.6.0` (it's in the reqs now)