### PR TITLE
Mixin refactor

### DIFF
--- a/tempus_dominus/widgets.py
+++ b/tempus_dominus/widgets.py
@@ -33,9 +33,11 @@ class TempusDominusMixin:
         Media = CDNMedia
 
     def __init__(self, attrs={'class': 'form-control datetimepicker-input'}, options=None):
-        super().__init__(attrs)
+        super().__init__()
         # If a dictionary of options is passed, combine it with our pre-set js_options.
-        if type(options) is dict:
+        self.js_options = {'format': self.get_js_format()}
+
+        if isinstance(options, dict):
             self.js_options = {**self.js_options, **options}
 
     def render(self, name, value, attrs={}, renderer=None):
@@ -92,35 +94,32 @@ class TempusDominusMixin:
 
         return {'defaultDate': value.isoformat()}
 
+    def get_js_format(self):
+        raise NotImplementedError
+
 
 class DatePicker(TempusDominusMixin, DateInput):
-    if getattr(settings, 'TEMPUS_DOMINUS_LOCALIZE', False):
-        js_format = 'L'
-    else:
-        js_format = 'YYYY-MM-DD'
-
-    js_options = {
-        'format': js_format,
-    }
+    def get_js_format(self):
+        if getattr(settings, 'TEMPUS_DOMINUS_LOCALIZE', False):
+            js_format = 'L'
+        else:
+            js_format = 'YYYY-MM-DD'
+        return js_format
 
 
 class DateTimePicker(TempusDominusMixin, DateTimeInput):
-    if getattr(settings, 'TEMPUS_DOMINUS_LOCALIZE', False):
-        js_format = 'L LTS'
-    else:
-        js_format = 'YYYY-MM-DD HH:mm:ss'
-
-    js_options = {
-        'format': js_format
-    }
+    def get_js_format(self):
+        if getattr(settings, 'TEMPUS_DOMINUS_LOCALIZE', False):
+            js_format = 'L LTS'
+        else:
+            js_format = 'YYYY-MM-DD HH:mm:ss'
+        return js_format
 
 
 class TimePicker(TempusDominusMixin, TimeInput):
-    if getattr(settings, 'TEMPUS_DOMINUS_LOCALIZE', False):
-        js_format = 'LTS'
-    else:
-        js_format = 'HH:mm:ss'
-
-    js_options = {
-        'format': js_format
-    }
+    def get_js_format(self):
+        if getattr(settings, 'TEMPUS_DOMINUS_LOCALIZE', False):
+            js_format = 'LTS'
+        else:
+            js_format = 'HH:mm:ss'
+        return js_format

--- a/tests/forms.py
+++ b/tests/forms.py
@@ -11,7 +11,6 @@ class TimeFieldForm(forms.Form):
     """Test form for TimePicker widget."""
     time_field = forms.TimeField(widget=TimePicker())
 
-
 class DateTimeFieldForm(forms.Form):
     """Test form for DateTimePicker widget."""
-    datetime_field = forms.DateTimeField(widget=DateTimePicker())
+    datetime_field = forms.DateTimeField(widget=DateTimePicker)

--- a/tests/test_form.py
+++ b/tests/test_form.py
@@ -1,16 +1,41 @@
+import importlib
+
 import pytest
 
-from .forms import DateFieldForm, TimeFieldForm, DateTimeFieldForm
+from . import forms
+from tempus_dominus import widgets
 
 
 
 @pytest.mark.parametrize("form_class", [
-    DateFieldForm,
-    TimeFieldForm,
-    DateTimeFieldForm,
+    forms.DateFieldForm,
+    forms.TimeFieldForm,
+    forms.DateTimeFieldForm,
 ])
 def test_forms_render(form_class):
     """
     Smoke test that forms render
     """
     assert form_class().as_p()
+
+
+def test_render_moment_unlocalized(settings):
+    form = forms.DateTimeFieldForm()
+    widget = form.fields['datetime_field'].widget
+    assert isinstance(
+        widget,
+        widgets.DateTimePicker
+    )
+    assert widget.js_options == {'format': 'YYYY-MM-DD HH:mm:ss'}
+
+
+def test_datetime_form_localization(settings):
+    settings.TEMPUS_DOMINUS_LOCALIZE = True
+    importlib.reload(forms)
+    form = forms.DateTimeFieldForm()
+    widget = form.fields['datetime_field'].widget
+    assert isinstance(
+        widget,
+        widgets.DateTimePicker
+    )
+    assert widget.js_options == {'format': 'L LTS'}

--- a/tests/test_widget.py
+++ b/tests/test_widget.py
@@ -1,0 +1,44 @@
+import pytest
+
+from tempus_dominus import widgets
+
+
+def test_datepicker_format_localized(settings):
+    settings.TEMPUS_DOMINUS_LOCALIZE = True
+    widget = widgets.DatePicker()
+    assert widget.get_js_format() == 'L'
+
+
+def test_datepicker_format_nonlocalized(settings):
+    settings.TEMPUS_DOMINUS_LOCALIZE = False
+    widget = widgets.DatePicker()
+    assert widget.get_js_format() == 'YYYY-MM-DD'
+
+
+def test_timepicker_format_localized(settings):
+    settings.TEMPUS_DOMINUS_LOCALIZE = True
+    widget = widgets.TimePicker()
+    assert widget.get_js_format() == 'LTS'
+
+
+def test_timepicker_format_nonlocalized(settings):
+    settings.TEMPUS_DOMINUS_LOCALIZE = False
+    widget = widgets.TimePicker()
+    assert widget.get_js_format() == 'HH:mm:ss'
+
+
+def test_datetimepicker_format_localized(settings):
+    settings.TEMPUS_DOMINUS_LOCALIZE = True
+    widget = widgets.DateTimePicker()
+    assert widget.get_js_format() == 'L LTS'
+
+
+def test_datetimepicker_format_nonlocalized(settings):
+    settings.TEMPUS_DOMINUS_LOCALIZE = False
+    widget = widgets.DateTimePicker()
+    assert widget.get_js_format() == 'YYYY-MM-DD HH:mm:ss'
+
+
+def test_get_js_format_error():
+    with pytest.raises(NotImplementedError):
+        widgets.TempusDominusMixin().get_js_format()


### PR DESCRIPTION
Refactors mixins to use a `get_js_format` method for generating the JS format string.

Adds tests for same.