### PR TITLE
Properly JSONifying widget JS options

### DIFF
--- a/tempus_dominus/widgets.py
+++ b/tempus_dominus/widgets.py
@@ -1,4 +1,5 @@
 from datetime import datetime
+import json
 
 from django import forms
 from django.utils.safestring import mark_safe
@@ -70,7 +71,7 @@ class TempusDominusMixin:
             'picker_id': context['widget']['attrs']['id'],
             'name': context['widget']['name'],
             'attrs': mark_safe(attr_html),
-            'js_options': mark_safe(options),
+            'js_options': mark_safe(json.dumps(options)),
         })
 
         return mark_safe(force_text(field_html))


### PR DESCRIPTION
In my previous PR (https://github.com/FlipperPA/django-tempus-dominus/pull/12), I didn't properly dump the JS options using `json.dumps`. Instead, it was cast as a string implicitly by `mark_safe`, which resulted in a multi-line string representation of the `dict`.

This change makes sure that the options are a properly formatted JSON string.