### PR TITLE
Corrected widget.py and widget template to allow time to be set.

### DIFF
--- a/tempus_dominus/templates/tempus_dominus/widget.html
+++ b/tempus_dominus/templates/tempus_dominus/widget.html
@@ -1,11 +1,12 @@
-<div class="input-group {% if size == 'small' %}input-group-sm{% elif size == 'large' %}input-group-lg{% endif %}">
+<div class="input-group {% if size == 'small' %}input-group-sm{% elif size == 'large' %}input-group-lg{% endif %}"
+  id="{{ picker_id }}" data-target-input="nearest">
   {% if prepend %}
     <div class="input-group-prepend" data-target="#{{ picker_id }}" {% if icon_toggle %}data-toggle="datetimepicker"{% endif %}>
       <div class="input-group-text"><i class="{{ prepend }}"></i></div>
     </div>
   {% endif %}
   <input type="{{ type }}" name="{{ name }}"{{ attrs }} {% if input_toggle %}data-toggle="datetimepicker"{% endif %}
-         data-target="#{{ picker_id }}" id="{{ picker_id }}">
+         data-target="#{{ picker_id }}">
   {% if append %}
     <div class="input-group-append" data-target="#{{ picker_id }}" {% if icon_toggle %}data-toggle="datetimepicker"{% endif %}>
         <div class="input-group-text"><i class="{{ append }}"></i></div>

--- a/tempus_dominus/widgets.py
+++ b/tempus_dominus/widgets.py
@@ -141,10 +141,12 @@ class TempusDominusMixin:
                     continue
             else:
                 return {}
-        # Append an option to set the datepicker's value
-        # This only works for Date or DateTime, not Time alone.
-        # NB returning defaultDate causes a javascript error
-        return {'date': value.isoformat()}
+        # Append an option to set the datepicker's value using iso formatted string
+        iso_date = value.isoformat()
+        # iso format for time requires a prepended T
+        if isinstance(self, TimePicker):
+            iso_date = 'T' + iso_date
+        return {'date': iso_date}
 
     def get_js_format(self):
         raise NotImplementedError


### PR DESCRIPTION
This corrects the issue where the initial value of a time field is not applied to the datepicker.
It required a change to the HTML tempate to assign the picker_id to the correct element and to closely match the examples on the tempus dominus site. It also required a change to the widget initialisation code to pass a time string with a prepended T e.g. 'T15:30:00'
As a bonus, it also seems to correct the recursion bug I documented with Firefox.