### PR TITLE
Added check to see if value is a list to support Django MultiWidgets

### DIFF
--- a/tempus_dominus/widgets.py
+++ b/tempus_dominus/widgets.py
@@ -121,7 +121,13 @@ class TempusDominusMixin:
         ):
             options["locale"] = get_language()
 
-        if context["widget"]["value"] is not None:
+        if type(context["widget"]["value"]) is list:
+            # If using the widget in a MultiWidget, values will be returned in
+            # a list and must be checked individually.
+            for value in context["widget"]["value"]:
+                if value is not None:
+                    options.update(self.moment_option(value))
+        elif context["widget"]["value"] is not None:
             # Append an option to set the datepicker's value using a Javascript
             # moment object
             options.update(self.moment_option(value))


### PR DESCRIPTION
Relates to #60 

I created a custom Django MultiWidget to support a SplitDateTimeField using django-tempus-dominus. In doing so, I encountered an error when calling moment_option(value) because value is a list when using a MultiWidget.

To fix this, I added a check to see if the widget is a list before calling moment_option. If it's a list, moment_option is called on every non-None value.

The MultiWidget can be found here: https://gist.github.com/nlittlejohns/748033df23a04f600801c8cfcc112c45