### PR TITLE
Fix Django 3.0 deprecation warning

### DIFF
--- a/tempus_dominus/widgets.py
+++ b/tempus_dominus/widgets.py
@@ -3,7 +3,7 @@ import json
 
 from django import forms
 from django.utils.safestring import mark_safe
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 from django.utils.formats import get_format
 from django.utils.translation import get_language
 from django.conf import settings
@@ -146,7 +146,7 @@ class TempusDominusMixin:
             },
         )
 
-        return mark_safe(force_text(field_html))
+        return mark_safe(force_str(field_html))
 
     def moment_option(self, value):
         """


### PR DESCRIPTION
Fix this deprecation warning on Django 3.0:

```
/.../lib/python3.7/site-packages/tempus_dominus/widgets.py:149: RemovedInDjango40Warning: force_text() is deprecated in favor of force_str().
 return mark_safe(force_text(field_html))
```

`force_str` has been available since (at least) Django 1.11 so this is compatible with all versions of Django that django-tempus-dominus supports.