### PR TITLE
Corrects assignment of formats

### DIFF
--- a/tempus_dominus/widgets.py
+++ b/tempus_dominus/widgets.py
@@ -160,11 +160,17 @@ class TempusDominusMixin:
         """
         if isinstance(value, str):
             if isinstance(self, DatePicker):
-                formats = [self.format] or get_format("DATE_INPUT_FORMATS")
+                formats = [self.format] if self.format else get_format(
+                    "DATE_INPUT_FORMATS"
+                )
             elif isinstance(self, TimePicker):
-                formats = [self.format] or get_format("TIME_INPUT_FORMATS")
+                formats = [self.format] if self.format else get_format(
+                    "TIME_INPUT_FORMATS"
+                )
             else:
-                formats = get_format("DATETIME_INPUT_FORMATS")
+                formats = [self.format] if self.format else get_format(
+                    "DATETIME_INPUT_FORMATS"
+                )
             for fmt in formats:
                 try:
                     value = datetime.strptime(value, fmt)


### PR DESCRIPTION
I made a booboo a couple months ago and set format to an array with self.format as the only cell regardless of the value of self.format. This meant that self.format=None would product formats of [None,], or something like that